### PR TITLE
Handle whitespaces in hidden inputs

### DIFF
--- a/lib/negative_captcha.rb
+++ b/lib/negative_captcha.rb
@@ -65,7 +65,7 @@ This usually happens because an automated script attempted to submit this form.
       self.error = "Error: Invalid timestamp.  #{message}"
     elsif params[:spinner] != spinner
       self.error = "Error: Invalid spinner.  #{message}"
-    elsif fields.keys.detect {|name| params[name] && params[name].length > 0}
+    elsif fields.keys.detect {|name| params[name] && params[name] =~ /\S/}
       self.error = <<-ERROR
 Error: Hidden form fields were submitted that should not have been. #{message}
       ERROR

--- a/test/negative_captcha_test.rb
+++ b/test/negative_captcha_test.rb
@@ -96,4 +96,17 @@ class NegativeCaptchaTest < Test::Unit::TestCase
     assert !filled_form.valid?
     assert filled_form.error.match(/hidden/i).is_a?(MatchData)
   end
+
+  def test_valid_submission_with_only_whitespaces_in_fields
+    fields = [:one, :two, :three]
+    captcha = NegativeCaptcha.new(:fields => fields)
+
+    filled_form = NegativeCaptcha.new(
+      :fields => fields,
+      :timestamp => captcha.timestamp,
+      :params => {:timestamp => captcha.timestamp, :spinner => captcha.spinner, :one => ' ', :two => "\r\n", :three => "\n"}.merge(captcha.fields.inject({}){|hash, name, encrypted_name| hash[encrypted_name] = name; hash})
+    )
+    assert_equal "", filled_form.error
+    assert filled_form.valid?
+  end
 end


### PR DESCRIPTION
This is a fix for #16 we are using in production currently. Some versions of Safari and Firefox insert \r\n or \n into empty textareas. 
