### PR TITLE
Loosen dependency on actionpack

### DIFF
--- a/negative_captcha.gemspec
+++ b/negative_captcha.gemspec
@@ -17,5 +17,5 @@ Gem::Specification.new do |s|
   ]
   s.require_paths = ['lib/']
 
-  s.add_dependency "actionpack", "~> 3.2"
+  s.add_dependency 'actionpack'
 end


### PR DESCRIPTION
We need actionpack but there is no need to require Rails 3 as it works just fine with Rails 2.

(It would probably even work with Rails 1. ;-))
