### PR TITLE
Do not include missed fields in values hash

### DIFF
--- a/lib/negative_captcha.rb
+++ b/lib/negative_captcha.rb
@@ -75,7 +75,7 @@ Error: Hidden form fields were submitted that should not have been. #{message}
       self.error = ""
 
       fields.each do |name, encrypted_name|
-        self.values[name] = params[encrypted_name]
+        self.values[name] = params[encrypted_name] if params.include? encrypted_name
       end
     end
   end

--- a/test/negative_captcha_test.rb
+++ b/test/negative_captcha_test.rb
@@ -34,6 +34,23 @@ class NegativeCaptchaTest < Test::Unit::TestCase
     assert_equal 'comment', filled_form.values[:comment]
   end
 
+  def test_missing_fields_are_not_in_values
+    fields = [:name, :comment, :widget]
+    captcha = NegativeCaptcha.new(:fields => fields)
+    assert captcha.fields.is_a?(Hash)
+    assert_equal captcha.fields.keys.sort{|a,b|a.to_s<=>b.to_s}, fields.sort{|a,b|a.to_s<=>b.to_s}
+
+    filled_form = NegativeCaptcha.new(
+      :fields => fields,
+      :timestamp => captcha.timestamp,
+      :params => {:timestamp => captcha.timestamp, :spinner => captcha.spinner}.merge(encrypted_params(captcha, [:name, :comment]))
+    )
+    assert_equal "", filled_form.error
+    assert filled_form.valid?
+
+    assert_equal({:name => 'name', :comment => 'comment'}, filled_form.values)
+  end
+
   def test_missing_timestamp
     fields = [:name, :comment]
     captcha = NegativeCaptcha.new(:fields => fields)


### PR DESCRIPTION
Necessary as one Captcha configuration may be used for multiple
configurations of the same form, and nulling out the data when the
form parameter is deliberately omitted is not desirable.
