### PR TITLE
With indifferent Hash access on values

### DIFF
--- a/lib/negative_captcha.rb
+++ b/lib/negative_captcha.rb
@@ -1,5 +1,6 @@
 require 'digest/md5'
 require 'action_view'
+require 'active_support/hash_with_indifferent_access'
 
 class NegativeCaptcha
   attr_accessor :fields,
@@ -42,7 +43,7 @@ This usually happens because an automated script attempted to submit this form.
       hash
     end
 
-    self.values = {}
+    self.values = HashWithIndifferentAccess.new
     self.error = "No params provided"
 
     if opts[:params] && (opts[:params][:spinner] || opts[:params][:timestamp])

--- a/negative_captcha.gemspec
+++ b/negative_captcha.gemspec
@@ -18,4 +18,5 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib/']
 
   s.add_dependency 'actionpack'
+  s.add_dependency 'activesupport'
 end

--- a/test/negative_captcha_test.rb
+++ b/test/negative_captcha_test.rb
@@ -32,6 +32,9 @@ class NegativeCaptchaTest < Test::Unit::TestCase
     assert filled_form.valid?
     assert_equal 'name', filled_form.values[:name]
     assert_equal 'comment', filled_form.values[:comment]
+
+    assert_equal 'name', filled_form.values['name']
+    assert_equal 'comment', filled_form.values['comment']
   end
 
   def test_missing_fields_are_not_in_values
@@ -48,7 +51,7 @@ class NegativeCaptchaTest < Test::Unit::TestCase
     assert_equal "", filled_form.error
     assert filled_form.valid?
 
-    assert_equal({:name => 'name', :comment => 'comment'}, filled_form.values)
+    assert_equal({'name' => 'name', 'comment' => 'comment'}, filled_form.values)
   end
 
   def test_missing_timestamp


### PR DESCRIPTION
Return values array as a HashWithIndifferentAccess, as that's what the params hash is.

Adds activesupport as a dependency, but if you have actionpack you'll have activesupport anyway.
