### PR TITLE
Replace homegrown crypto with safer constructs

### DIFF
--- a/lib/negative_captcha.rb
+++ b/lib/negative_captcha.rb
@@ -1,6 +1,6 @@
-require 'digest/md5'
 require 'action_view'
 require 'active_support/hash_with_indifferent_access'
+require 'openssl'
 
 class NegativeCaptcha
   attr_accessor :fields,
@@ -16,9 +16,8 @@ class NegativeCaptcha
     class_variable_set(:@@test_mode, value)
   end
 
-  def initialize(opts)
-    self.secret = opts[:secret] ||
-      Digest::MD5.hexdigest("this_is_a_secret_key")
+  def initialize(secret, opts)
+    self.secret = secret
 
     if opts.has_key?(:params)
       self.timestamp = opts[:params][:timestamp] || Time.now.to_i
@@ -26,8 +25,10 @@ class NegativeCaptcha
       self.timestamp = Time.now.to_i
     end
 
-    self.spinner = Digest::MD5.hexdigest(
-      ([timestamp, secret] + Array(opts[:spinner])).join('-')
+    self.spinner = self.generate_session_secret(
+      self.secret,
+      self.timestamp,
+      opts[:spinner]
     )
 
     self.message = opts[:message] || <<-MESSAGE
@@ -35,12 +36,9 @@ Please try again.
 This usually happens because an automated script attempted to submit this form.
     MESSAGE
 
-    self.fields = opts[:fields].inject({}) do |hash, field_name|
-      hash[field_name] = @@test_mode ? "test-#{field_name}" : Digest::MD5.hexdigest(
-        [field_name, spinner, secret].join('-')
-      )
-
-      hash
+    self.fields = opts[:fields].each_with_object({}) do |hash, field_name|
+      hash[field_name]   = "test-#{field_name}" if @@test_mode
+      hash[field_name] ||= self.generate_authenticator(self.spinner, field_name)
     end
 
     self.values = HashWithIndifferentAccess.new
@@ -75,10 +73,40 @@ Error: Hidden form fields were submitted that should not have been. #{message}
     else
       self.error = ""
 
-      fields.each do |name, encrypted_name|
-        self.values[name] = params[encrypted_name] if params.include? encrypted_name
+      fields.each do |name, authenticator|
+        self.values[name] = params[authenticator] if params.include? authenticator
       end
     end
+  end
+  
+  protected
+  
+  def generate_session_secret(secret, nonce, context)
+    # securely compose the message by using fixed-size 64-bit length prefixes
+    # before each component
+    nonce          = nonce  .to_s
+    context        = context.to_s
+    nonce_length   = [ timestamp.length ].pack('Q>')
+    context_length = [ context  .length ].pack('Q>')
+    
+    message = (
+      nonce_length   + nonce
+      context_length + context
+    )
+
+    self.generate_authenticator(secret, message)
+  end
+  
+  def generate_authenticator(secret, message)
+    # decode the secret from hex into raw bytes
+    secret = [ secret ].pack('H*')
+    
+    # compute HMAC-SHA-256 of the message
+    OpenSSL::HMAC.hexdigest(
+      OpenSSL::Digest::SHA256.new,
+      key,
+      message
+    )
   end
 end
 


### PR DESCRIPTION
1. Default, non-random secrets are _always_ a bad idea.
2. MD5 is not a good passphrase hashing function.
3. MD5, while not _yet_ vulnerable to preimage attacks (which would allow forging "spinners") will only get weaker over time, and should not be used in new projects.
4. Raw hash functions are not suitable for use as message authenticators.

That said, this PR makes a few changes:
1. The default secret is removed, so users must specify them explicitly.
2. All uses of MD5 have been removed.
3. Concatenated strings as authenticators have been replaced with HMAC constructions.

To elaborate on the change to HMACs: Simply concatenating a secret to a message and hashing it does not constitute a secure construction. [HMAC](http://en.wikipedia.org/wiki/Hash-based_message_authentication_code)s are used for this purpose, and are specifically designed to avoid things like length extension attacks as well as maintain some security even in the face of collisions in the unkeyed hash function.

Additionally, strings can't simply be concatenated to form the message. This can allow attackers to [manipulate message boundaries](http://security.stackexchange.com/questions/2202/lessons-learned-and-misconceptions-regarding-encryption-and-cryptology/2212#2212). You attempted to use hyphens, but the output of `Time.now` already includes them and so they cannot be reliably used to delineate message boundaries. Length prefixes are a sufficient solution (as suggested in the linked article).

Full disclosure: I have not run the tests for this change. I edited it in the GitHub editor. You should probably run the tests. I porblaby hvae a tpyo soemwheer.

As one final concern, timestamps are being used to create unique "session keys" for each user. Timestamps are predictable, and predictability is not a good idea here. You should be using randomly-generated nonces. As this requires a change across multiple files (to change the parameter name), I haven't submitted it as part of this edit.
