### PR TITLE
added negative_email_field_tag to helpers

### DIFF
--- a/lib/negative_captcha/form_builder.rb
+++ b/lib/negative_captcha/form_builder.rb
@@ -15,6 +15,20 @@ module ActionView
         html.html_safe
       end
 
+      def negative_email_field(captcha, method, options = {})
+        html = @template.negative_email_field_tag(
+          captcha,
+          method,
+          options
+        ).html_safe
+
+        if @object.errors[method].present?
+          html = "<div class='fieldWithErrors'>#{html}</div>"
+        end
+
+        html.html_safe
+      end
+
       def negative_text_area(captcha, method, options = {})
         html = @template.negative_text_area_tag(
           captcha,

--- a/lib/negative_captcha/view_helpers.rb
+++ b/lib/negative_captcha/view_helpers.rb
@@ -19,6 +19,17 @@ module ActionView
         end.html_safe
       end
 
+      def negative_email_field_tag(negative_captcha, field, options={})
+        email_field_tag(
+          negative_captcha.fields[field],
+          negative_captcha.values[field],
+          options
+        ) +
+          content_tag('div', :style => 'position: absolute; left: -2000px;') do
+          email_field_tag(field, '', :tabindex => '999', :autocomplete => 'off')
+        end.html_safe
+      end
+
       def negative_text_area_tag(negative_captcha, field, options={})
         text_area_tag(
           negative_captcha.fields[field],


### PR DESCRIPTION
I added a negative_email_field_tag to the helpers as I was already using it, and it provides better usability for users especially on mobile.

Thanks for this awesome gem, it is really useful.