### PR TITLE
Improved negative_label_tag to accept block

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -121,7 +121,9 @@ Modify your form to include the honeypots and other fields. You can probably lea
       <%= negative_text_field_tag(@captcha, :email) %>
     </li>
     <li>
-      <%= negative_label_tag(@captcha, :body, 'Your Comment:') %>
+      <%= negative_label_tag(@captcha, :body, 'Your Comment:') do %>
+        <span>Accepts a block.</span>
+      <% end %>
       <%= negative_text_area_tag(@captcha, :body) %>
     </li>
     <li>

--- a/lib/negative_captcha/form_builder.rb
+++ b/lib/negative_captcha/form_builder.rb
@@ -75,12 +75,13 @@ module ActionView
         html.html_safe
       end
 
-      def negative_label(captcha, method, name, options = {})
+      def negative_label(captcha, method, name, options = {}, &block)
         html = @template.negative_label_tag(
           captcha,
           method,
           name,
-          options
+          options,
+          &block
         ).html_safe
 
         if @object.errors[method].present?

--- a/lib/negative_captcha/view_helpers.rb
+++ b/lib/negative_captcha/view_helpers.rb
@@ -73,8 +73,8 @@ module ActionView
         end.html_safe
       end
 
-      def negative_label_tag(negative_captcha, field, name, options={})
-        label_tag(negative_captcha.fields[field], name, options)
+      def negative_label_tag(negative_captcha, field, name, options={}, &block)
+        label_tag(negative_captcha.fields[field], name, options, &block)
       end
     end
 


### PR DESCRIPTION
A small feature that makes ```negative_label_tag``` and ```negative_label``` accept a block of code.

Example:
```erb
<%= negative_label_tag(@captcha, :foo, 'Foo:') do %>
    <span>Your block here.</span>
<% end %>
```
```erb
<%= negative_label(@captcha, :bar, 'Bar:') do %>
    <span>And here.</span>
<% end %>
```


Resolves #15