### PR TITLE
Update README to warn against use of Negative Captcha with caching

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -133,6 +133,10 @@ Modify your form to include the honeypots and other fields. You can probably lea
 <% end -%>
 ```
 
+### Caching / Use in Production
+
+Note that if you serve cached form markup generated with Negative Captcha and have the :spinner property in NegativeCaptcha.new set to a client-specific value, NegativeCaptcha will be unable to decode any form submission by a client other than the client used to warm the cache. Be sure to re-render all forms generated with Negative Captcha upon each request. 
+
 ### Test and enjoy!
 
 ## Possible Gotchas and other concerns


### PR DESCRIPTION
I could be wrong about this, but I just spent a bit of time looking through the source code here and trying to debug an issue on my production servers, and the conclusion that I came to was that it was caused by caching. If I'm correct, I figure this could be worth including here to save others from running into the same issue. Big fan of the concept and gem.