### PR TITLE
Fix checkbox tags

### DIFF
--- a/lib/negative_captcha/view_helpers.rb
+++ b/lib/negative_captcha/view_helpers.rb
@@ -65,12 +65,12 @@ module ActionView
       def negative_check_box_tag(negative_captcha, field, options={})
         check_box_tag(
           negative_captcha.fields[field],
-          negative_captcha.values[field],
+          '1',
           negative_captcha.values[field].present?,
           options
         ) +
         content_tag('div', :style => negative_captcha.css) do
-          check_box_tag(field, '', :tabindex => '999')
+          check_box_tag(field, '1', :tabindex => '999')
         end
       end
 

--- a/lib/negative_captcha/view_helpers.rb
+++ b/lib/negative_captcha/view_helpers.rb
@@ -70,7 +70,7 @@ module ActionView
           options
         ) +
         content_tag('div', :style => negative_captcha.css) do
-          check_box_tag(field, '1', :tabindex => '999')
+          check_box_tag(field, '1', false, :tabindex => '999')
         end
       end
 

--- a/lib/negative_captcha/view_helpers.rb
+++ b/lib/negative_captcha/view_helpers.rb
@@ -66,6 +66,7 @@ module ActionView
         check_box_tag(
           negative_captcha.fields[field],
           negative_captcha.values[field],
+          negative_captcha.values[field].present?,
           options
         ) +
         content_tag('div', :style => negative_captcha.css) do

--- a/test/view_helpers_test.rb
+++ b/test/view_helpers_test.rb
@@ -1,0 +1,20 @@
+require "action_view"
+require 'test/unit'
+require_relative '../lib/negative_captcha'
+
+class ActionView::Helpers::ViewHelpersTest < ActionView::TestCase
+  include ActionView::Helpers::FormTagHelper
+  include ActionView::Helpers::NegativeCaptchaHelpers
+
+  def test_options_are_passed_to_rails_helper
+    fields = [:accept_tos]
+
+    captcha = NegativeCaptcha.new :fields => fields
+    captcha.values[:accept_tos] = "on"
+
+    actual = negative_check_box_tag captcha, :accept_tos, :class => 'tos'
+    expected = /<input checked="checked" class="tos" id="#{captcha[:accept_tos]}" name="#{captcha[:accept_tos]}" type="checkbox"/
+
+    assert_match actual, expected
+  end
+end


### PR DESCRIPTION
This is just a quick attempt to fix #44, on top of the commit mentioned by @veezus in https://github.com/subwindow/negative-captcha/issues/44#issuecomment-102163205

A better improvement would probably be to change the method signatures to match [`FormHelper#check_box`](http://apidock.com/rails/ActionView/Helpers/FormHelper/check_box) and [`FormTagHelper#check_box_tag`](http://apidock.com/rails/ActionView/Helpers/FormTagHelper/check_box_tag) respectively. However, this at least makes the current methods behave as advertised.
