### PR TITLE
Removes duplicated negative_email_field_tag

### DIFF
--- a/lib/negative_captcha/view_helpers.rb
+++ b/lib/negative_captcha/view_helpers.rb
@@ -100,17 +100,6 @@ module ActionView
         end.html_safe
       end
 
-      def negative_email_field_tag(negative_captcha, field, options={})
-        email_field_tag(
-          negative_captcha.fields[field],
-          negative_captcha.values[field],
-          options
-        ) +
-        content_tag('div', :style => negative_captcha.css) do
-          number_field_tag(field, '', :tabindex => '999')
-        end.html_safe
-      end
-
       def negative_phone_field_tag(negative_captcha, field, options={})
         phone_field_tag(
           negative_captcha.fields[field],


### PR DESCRIPTION
It appears in #53 I had added a second time `negative_email_field_tag` helper. This PR removes this redefinition.